### PR TITLE
feat: adapted Python JSON parsers

### DIFF
--- a/backend/libraries/ballerina-core-python/.vscode/settings.json
+++ b/backend/libraries/ballerina-core-python/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "python.testing.pytestArgs": [
+        "ballerina_core"
+    ],
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true
+}

--- a/backend/libraries/ballerina-core-python/.vscode/settings.json
+++ b/backend/libraries/ballerina-core-python/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
     "python.testing.pytestArgs": [
-        "ballerina_core"
+        "tests"
     ],
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true

--- a/backend/libraries/ballerina-core-python/ballerina_core/option.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/option.py
@@ -6,7 +6,6 @@ from typing import Generic, TypeVar, assert_never
 
 _Option = TypeVar("_Option")
 _Some = TypeVar("_Some")
-_Nothing = TypeVar("_Nothing")
 
 
 @dataclass(frozen=True)
@@ -18,10 +17,10 @@ class Option(Generic[_Option]):
         _C = TypeVar("_C")
 
     @dataclass(frozen=True)
-    class Nothing(Generic[_Nothing]):
+    class Nothing:
         pass
 
-    value: Some[_Option] | Nothing[_Option]
+    value: Some[_Option] | Nothing
 
     _O = TypeVar("_O")
 
@@ -30,7 +29,7 @@ class Option(Generic[_Option]):
         return Option(Option.Some(value))
 
     @staticmethod
-    def nothing() -> Option[_Option]:
+    def none() -> Option[_Option]:
         return Option(Option.Nothing())
 
     def fold(self, on_some: Callable[[_Option], _O], on_nothing: Callable[[], _O], /) -> _O:
@@ -42,7 +41,7 @@ class Option(Generic[_Option]):
         assert_never(self.value)
 
     def map(self, on_some: Callable[[_Option], _O], /) -> Option[_O]:
-        return self.fold(lambda value: Option.some(on_some(value)), Option.nothing)
+        return self.fold(lambda value: Option.some(on_some(value)), Option.none)
 
     def flat_map(self, on_some: Callable[[_Option], Option[_O]], /) -> Option[_O]:
-        return self.fold(on_some, Option.nothing)
+        return self.fold(on_some, Option.none)

--- a/backend/libraries/ballerina-core-python/ballerina_core/parsing/list.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/parsing/list.py
@@ -12,7 +12,7 @@ _KIND_KEY: str = "kind"
 
 def list_to_json(item_to_json: ToJson[_A]) -> ToJson[list[_A]]:
     def to_json(value: list[_A]) -> Json:
-        return {_KIND_KEY: "tuple", "elements": [item_to_json(item) for item in value]}
+        return {_KIND_KEY: "list", "elements": [item_to_json(item) for item in value]}
 
     return to_json
 
@@ -20,13 +20,13 @@ def list_to_json(item_to_json: ToJson[_A]) -> ToJson[list[_A]]:
 def list_from_json(item_from_json: FromJson[_A]) -> FromJson[list[_A]]:
     def from_json(value: Json) -> list[_A]:
         match value:
-            case {"kind": "tuple", "elements": tuple_value}:
+            case {"kind": "list", "elements": tuple_value}:
                 match tuple_value:
                     case list():
                         return [item_from_json(item) for item in tuple_value]
                     case _:
                         raise ValueError(f"Not a list: {tuple_value}")
             case _:
-                raise ValueError(f"Not a tuple: {value}")
+                raise ValueError(f"Not a list: {value}")
 
     return from_json

--- a/backend/libraries/ballerina-core-python/ballerina_core/parsing/list.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/parsing/list.py
@@ -7,9 +7,12 @@ from ballerina_core.parsing.parsing_types import FromJson, Json, ToJson
 _A = TypeVar("_A")
 
 
+_KIND_KEY: str = "kind"
+
+
 def list_to_json(item_to_json: ToJson[_A]) -> ToJson[list[_A]]:
     def to_json(value: list[_A]) -> Json:
-        return [item_to_json(item) for item in value]
+        return {_KIND_KEY: "tuple", "elements": [item_to_json(item) for item in value]}
 
     return to_json
 
@@ -17,9 +20,13 @@ def list_to_json(item_to_json: ToJson[_A]) -> ToJson[list[_A]]:
 def list_from_json(item_from_json: FromJson[_A]) -> FromJson[list[_A]]:
     def from_json(value: Json) -> list[_A]:
         match value:
-            case list():
-                return [item_from_json(item) for item in value]
+            case {"kind": "tuple", "elements": tuple_value}:
+                match tuple_value:
+                    case list():
+                        return [item_from_json(item) for item in tuple_value]
+                    case _:
+                        raise ValueError(f"Not a list: {tuple_value}")
             case _:
-                raise ValueError(f"Not a list: {value}")
+                raise ValueError(f"Not a tuple: {value}")
 
     return from_json

--- a/backend/libraries/ballerina-core-python/ballerina_core/parsing/list.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/parsing/list.py
@@ -20,12 +20,12 @@ def list_to_json(item_to_json: ToJson[_A]) -> ToJson[list[_A]]:
 def list_from_json(item_from_json: FromJson[_A]) -> FromJson[list[_A]]:
     def from_json(value: Json) -> list[_A]:
         match value:
-            case {"kind": "list", "elements": tuple_value}:
-                match tuple_value:
+            case {"kind": "list", "elements": elements}:
+                match elements:
                     case list():
-                        return [item_from_json(item) for item in tuple_value]
+                        return [item_from_json(item) for item in elements]
                     case _:
-                        raise ValueError(f"Not a list: {tuple_value}")
+                        raise ValueError(f"Not a list: {elements}")
             case _:
                 raise ValueError(f"Not a list: {value}")
 

--- a/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from decimal import Decimal
 
 from ballerina_core.parsing.parsing_types import Json
+from ballerina_core.unit import Unit, unit
 
 _KIND_KEY: str = "kind"
 
@@ -35,14 +36,14 @@ def int_from_json(value: Json) -> int:
             raise ValueError(f"Not an int: {value}")
 
 
-def unit_to_json() -> Json:
+def unit_to_json(_: Unit) -> Json:
     return {_KIND_KEY: "unit"}
 
 
-def unit_from_json(value: Json) -> None:
+def unit_from_json(value: Json) -> Unit:
     match value:
         case {"kind": "unit"}:
-            return None  # noqa:RET501
+            return unit
         case _:
             raise ValueError(f"Not a unit: {value}")
 

--- a/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
@@ -5,11 +5,11 @@ from decimal import Decimal
 from ballerina_core.parsing.parsing_types import Json
 
 
-def str_to_json(value: str) -> str:
+def string_to_json(value: str) -> str:
     return value
 
 
-def str_from_json(value: Json) -> str:
+def string_from_json(value: Json) -> str:
     match value:
         case str():
             return value
@@ -29,11 +29,11 @@ def int_from_json(value: Json) -> int:
             raise ValueError(f"Not an int: {value}")
 
 
-def none_to_json() -> Json:
+def unit_to_json() -> Json:
     return None
 
 
-def none_from_json(value: Json) -> None:
+def unit_from_json(value: Json) -> None:
     match value:
         case None:
             return
@@ -53,11 +53,11 @@ def bool_from_json(value: Json) -> bool:
             raise ValueError(f"Not a bool: {value}")
 
 
-def decimal_to_json(value: Decimal) -> Json:
+def float_to_json(value: Decimal) -> Json:
     return str(value)
 
 
-def decimal_from_json(value: Json) -> Decimal:
+def float_from_json(value: Json) -> Decimal:
     match value:
         case str():
             return Decimal(value)

--- a/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
@@ -8,7 +8,7 @@ from ballerina_core.unit import Unit, unit
 _KIND_KEY: str = "kind"
 
 
-def string_to_json(value: str) -> str:
+def string_to_json(value: str) -> Json:
     return value
 
 

--- a/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
@@ -21,15 +21,15 @@ def string_from_json(value: Json) -> str:
 
 
 def int_to_json(value: int) -> Json:
-    return {_KIND_KEY: "int", "value": value}
+    return {_KIND_KEY: "int", "value": str(value)}
 
 
 def int_from_json(value: Json) -> int:
     match value:
         case {"kind": "int", "value": int_value}:
             match int_value:
-                case int():
-                    return int_value
+                case str():
+                    return int(int_value)
                 case _:
                     raise ValueError(f"Not an int: {int_value}")
         case _:

--- a/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/parsing/primitives.py
@@ -4,6 +4,8 @@ from decimal import Decimal
 
 from ballerina_core.parsing.parsing_types import Json
 
+_KIND_KEY: str = "kind"
+
 
 def string_to_json(value: str) -> str:
     return value
@@ -18,27 +20,31 @@ def string_from_json(value: Json) -> str:
 
 
 def int_to_json(value: int) -> Json:
-    return value
+    return {_KIND_KEY: "int", "value": value}
 
 
 def int_from_json(value: Json) -> int:
     match value:
-        case int():
-            return value
+        case {"kind": "int", "value": int_value}:
+            match int_value:
+                case int():
+                    return int_value
+                case _:
+                    raise ValueError(f"Not an int: {int_value}")
         case _:
             raise ValueError(f"Not an int: {value}")
 
 
 def unit_to_json() -> Json:
-    return None
+    return {_KIND_KEY: "unit"}
 
 
 def unit_from_json(value: Json) -> None:
     match value:
-        case None:
-            return
+        case {"kind": "unit"}:
+            return None  # noqa:RET501
         case _:
-            raise ValueError(f"Not None: {value}")
+            raise ValueError(f"Not a unit: {value}")
 
 
 def bool_to_json(value: bool) -> Json:  # noqa: FBT001
@@ -54,12 +60,16 @@ def bool_from_json(value: Json) -> bool:
 
 
 def float_to_json(value: Decimal) -> Json:
-    return str(value)
+    return {_KIND_KEY: "float", "value": str(value)}
 
 
 def float_from_json(value: Json) -> Decimal:
     match value:
-        case str():
-            return Decimal(value)
+        case {"kind": "float", "value": float_value}:
+            match float_value:
+                case str():
+                    return Decimal(float_value)
+                case _:
+                    raise ValueError(f"Not a float: {float_value}")
         case _:
-            raise ValueError(f"Not a string: {value}")
+            raise ValueError(f"Not a float: {value}")

--- a/backend/libraries/ballerina-core-python/ballerina_core/unit.py
+++ b/backend/libraries/ballerina-core-python/ballerina_core/unit.py
@@ -1,0 +1,4 @@
+from typing import NewType
+
+Unit = NewType("Unit", tuple[()])
+unit: Unit = Unit(())

--- a/backend/libraries/ballerina-core-python/tests/option_test.py
+++ b/backend/libraries/ballerina-core-python/tests/option_test.py
@@ -11,13 +11,13 @@ class TestOption:
 
     @staticmethod
     def test_nothing() -> None:
-        option: Option[int] = Option.nothing()
+        option: Option[int] = Option.none()
         result = option.fold(lambda x: x * 2, lambda: 0)
         assert result == 0
 
     @staticmethod
     def test_fold_with_none() -> None:
-        option: Option[int] = Option.nothing()
+        option: Option[int] = Option.none()
         result = option.fold(lambda x: x * 2, lambda: None)
         assert result is None
 
@@ -37,9 +37,9 @@ class TestOption:
 
     @staticmethod
     def test_map_with_none() -> None:
-        option: Option[int] = Option.nothing()
+        option: Option[int] = Option.none()
         result = option.map(lambda x: x * 2)
-        assert result == Option.nothing()
+        assert result == Option.none()
 
     @staticmethod
     def test_flat_map_with_some() -> None:
@@ -50,6 +50,6 @@ class TestOption:
 
     @staticmethod
     def test_flat_map_with_none() -> None:
-        option: Option[int] = Option.nothing()
+        option: Option[int] = Option.none()
         result = option.flat_map(lambda x: Option.some(x * 2))
-        assert result == Option.nothing()
+        assert result == Option.none()

--- a/backend/libraries/ballerina-core-python/tests/parsing/option_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/option_test.py
@@ -10,7 +10,7 @@ class TestOptionSerializer:
         value = Option.some(42)
         serializer = option_to_json(int_to_json)
         serialized = serializer(value)
-        assert serialized == {"case": "some", "value": 42}
+        assert serialized == {"case": "some", "value": int_to_json(42)}
 
     @staticmethod
     def test_option_to_json_none() -> None:
@@ -21,7 +21,7 @@ class TestOptionSerializer:
 
     @staticmethod
     def test_option_from_json_some() -> None:
-        serialized: Json = {"case": "some", "value": 42}
+        serialized: Json = {"case": "some", "value": int_to_json(42)}
         deserializer = option_from_json(int_from_json)
         value = deserializer(serialized)
         assert value == Option.some(42)

--- a/backend/libraries/ballerina-core-python/tests/parsing/option_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/option_test.py
@@ -22,13 +22,13 @@ class TestOptionSerializer:
     @staticmethod
     def test_option_from_json_some() -> None:
         serialized: Json = {"case": "some", "value": int_to_json(42)}
-        deserializer = option_from_json(int_from_json)
-        value = deserializer(serialized)
+        parser = option_from_json(int_from_json)
+        value = parser(serialized)
         assert value == Option.some(42)
 
     @staticmethod
     def test_option_from_json_none() -> None:
         serialized: Json = {"case": "nothing", "value": None}
-        deserializer = option_from_json(int_from_json)
-        value = deserializer(serialized)
+        parser = option_from_json(int_from_json)
+        value = parser(serialized)
         assert value == Option.nothing()

--- a/backend/libraries/ballerina-core-python/tests/parsing/option_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/option_test.py
@@ -1,34 +1,35 @@
 from ballerina_core.option import Option
 from ballerina_core.parsing.option import option_from_json, option_to_json
 from ballerina_core.parsing.parsing_types import Json
-from ballerina_core.parsing.primitives import int_from_json, int_to_json
+from ballerina_core.parsing.primitives import int_from_json, int_to_json, unit_from_json, unit_to_json
+from ballerina_core.unit import unit
 
 
 class TestOptionSerializer:
     @staticmethod
     def test_option_to_json_some() -> None:
         value = Option.some(42)
-        serializer = option_to_json(int_to_json)
+        serializer = option_to_json(int_to_json, unit_to_json)
         serialized = serializer(value)
         assert serialized == {"case": "some", "value": int_to_json(42)}
 
     @staticmethod
     def test_option_to_json_none() -> None:
-        value: Option[int] = Option.nothing()
-        serializer = option_to_json(int_to_json)
+        value: Option[int] = Option.none()
+        serializer = option_to_json(int_to_json, unit_to_json)
         serialized = serializer(value)
-        assert serialized == {"case": "nothing", "value": None}
+        assert serialized == {"case": "none", "value": unit_to_json(unit)}
 
     @staticmethod
     def test_option_from_json_some() -> None:
         serialized: Json = {"case": "some", "value": int_to_json(42)}
-        parser = option_from_json(int_from_json)
+        parser = option_from_json(int_from_json, unit_from_json)
         value = parser(serialized)
         assert value == Option.some(42)
 
     @staticmethod
     def test_option_from_json_none() -> None:
-        serialized: Json = {"case": "nothing", "value": None}
-        parser = option_from_json(int_from_json)
+        serialized: Json = {"case": "none", "value": unit_to_json(unit)}
+        parser = option_from_json(int_from_json, unit_from_json)
         value = parser(serialized)
-        assert value == Option.nothing()
+        assert value == Option.none()

--- a/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
@@ -75,11 +75,11 @@ class TestListSerializer:
         value = [1, 2, 3]
         serializer = list_to_json(int_to_json)
         serialized = serializer(value)
-        assert serialized == {"kind": "tuple", "elements": [int_to_json(1), int_to_json(2), int_to_json(3)]}
+        assert serialized == {"kind": "list", "elements": [int_to_json(1), int_to_json(2), int_to_json(3)]}
 
     @staticmethod
     def test_list_from_json() -> None:
-        serialized: Json = {"kind": "tuple", "elements": [int_to_json(1), int_to_json(2), int_to_json(3)]}
+        serialized: Json = {"kind": "list", "elements": [int_to_json(1), int_to_json(2), int_to_json(3)]}
         parser = list_from_json(int_from_json)
         value = parser(serialized)
         assert value == [1, 2, 3]

--- a/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
@@ -79,6 +79,6 @@ class TestListSerializer:
     @staticmethod
     def test_list_from_json() -> None:
         serialized: Json = [int_to_json(1), int_to_json(2), int_to_json(3)]
-        deserializer = list_from_json(int_from_json)
-        value = deserializer(serialized)
+        parser = list_from_json(int_from_json)
+        value = parser(serialized)
         assert value == [1, 2, 3]

--- a/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
@@ -14,6 +14,7 @@ from ballerina_core.parsing.primitives import (
     unit_from_json,
     unit_to_json,
 )
+from ballerina_core.unit import unit
 
 
 class TestPrimitivesSerializer:
@@ -40,12 +41,12 @@ class TestPrimitivesSerializer:
 
     @staticmethod
     def test_unit_to_json() -> None:
-        assert unit_to_json() == {"kind": "unit"}
+        assert unit_to_json(unit) == {"kind": "unit"}
 
     @staticmethod
     def test_unit_from_json() -> None:
         serialized: Json = {"kind": "unit"}
-        assert unit_from_json(serialized) is None  # type: ignore[func-returns-value]
+        assert unit_from_json(serialized) == unit
 
     @staticmethod
     def test_bool_to_json() -> None:

--- a/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
@@ -74,11 +74,11 @@ class TestListSerializer:
         value = [1, 2, 3]
         serializer = list_to_json(int_to_json)
         serialized = serializer(value)
-        assert serialized == [int_to_json(1), int_to_json(2), int_to_json(3)]
+        assert serialized == {"kind": "tuple", "elements": [int_to_json(1), int_to_json(2), int_to_json(3)]}
 
     @staticmethod
     def test_list_from_json() -> None:
-        serialized: Json = [int_to_json(1), int_to_json(2), int_to_json(3)]
+        serialized: Json = {"kind": "tuple", "elements": [int_to_json(1), int_to_json(2), int_to_json(3)]}
         parser = list_from_json(int_from_json)
         value = parser(serialized)
         assert value == [1, 2, 3]

--- a/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
@@ -5,14 +5,14 @@ from ballerina_core.parsing.parsing_types import Json
 from ballerina_core.parsing.primitives import (
     bool_from_json,
     bool_to_json,
-    decimal_from_json,
-    decimal_to_json,
+    float_from_json,
+    float_to_json,
     int_from_json,
     int_to_json,
-    none_from_json,
-    none_to_json,
-    str_from_json,
-    str_to_json,
+    string_from_json,
+    string_to_json,
+    unit_from_json,
+    unit_to_json,
 )
 
 
@@ -28,24 +28,24 @@ class TestPrimitivesSerializer:
         assert int_from_json(serialized) == serialized
 
     @staticmethod
-    def test_str_to_json() -> None:
+    def test_string_to_json() -> None:
         value = "hello"
-        assert str_to_json(value) == value
+        assert string_to_json(value) == value
 
     @staticmethod
-    def test_str_from_json() -> None:
+    def test_string_from_json() -> None:
         serialized: Json = "hello"
-        assert str_from_json(serialized) == serialized
+        assert string_from_json(serialized) == serialized
 
     @staticmethod
-    def test_none_to_json() -> None:
+    def test_unit_to_json() -> None:
         value = None
-        assert none_to_json() == value
+        assert unit_to_json() == value
 
     @staticmethod
-    def test_none_from_json() -> None:
+    def test_unit_from_json() -> None:
         serialized: Json = None
-        assert none_from_json(serialized) == serialized  # type: ignore[func-returns-value]
+        assert unit_from_json(serialized) == serialized  # type: ignore[func-returns-value]
 
     @staticmethod
     def test_bool_to_json() -> None:
@@ -58,14 +58,14 @@ class TestPrimitivesSerializer:
         assert bool_from_json(serialized) == serialized
 
     @staticmethod
-    def test_decimal_to_json() -> None:
+    def test_float_to_json() -> None:
         value = Decimal("3.14")
-        assert decimal_to_json(value) == "3.14"
+        assert float_to_json(value) == "3.14"
 
     @staticmethod
-    def test_decimal_from_json() -> None:
+    def test_float_from_json() -> None:
         serialized: Json = "3.14"
-        assert decimal_from_json(serialized) == Decimal("3.14")
+        assert float_from_json(serialized) == Decimal("3.14")
 
 
 class TestListSerializer:

--- a/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
@@ -21,12 +21,12 @@ class TestPrimitivesSerializer:
     @staticmethod
     def test_int_to_json() -> None:
         value = 42
-        assert int_to_json(value) == {"kind": "int", "value": 42}
+        assert int_to_json(value) == {"kind": "int", "value": "42"}
 
     @staticmethod
     def test_int_from_json() -> None:
         value = 42
-        serialized: Json = {"kind": "int", "value": value}
+        serialized: Json = {"kind": "int", "value": "42"}
         assert int_from_json(serialized) == value
 
     @staticmethod

--- a/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/primitives_test.py
@@ -20,12 +20,13 @@ class TestPrimitivesSerializer:
     @staticmethod
     def test_int_to_json() -> None:
         value = 42
-        assert int_to_json(value) == value
+        assert int_to_json(value) == {"kind": "int", "value": 42}
 
     @staticmethod
     def test_int_from_json() -> None:
-        serialized: Json = 42
-        assert int_from_json(serialized) == serialized
+        value = 42
+        serialized: Json = {"kind": "int", "value": value}
+        assert int_from_json(serialized) == value
 
     @staticmethod
     def test_string_to_json() -> None:
@@ -39,13 +40,12 @@ class TestPrimitivesSerializer:
 
     @staticmethod
     def test_unit_to_json() -> None:
-        value = None
-        assert unit_to_json() == value
+        assert unit_to_json() == {"kind": "unit"}
 
     @staticmethod
     def test_unit_from_json() -> None:
-        serialized: Json = None
-        assert unit_from_json(serialized) == serialized  # type: ignore[func-returns-value]
+        serialized: Json = {"kind": "unit"}
+        assert unit_from_json(serialized) is None  # type: ignore[func-returns-value]
 
     @staticmethod
     def test_bool_to_json() -> None:
@@ -60,11 +60,11 @@ class TestPrimitivesSerializer:
     @staticmethod
     def test_float_to_json() -> None:
         value = Decimal("3.14")
-        assert float_to_json(value) == "3.14"
+        assert float_to_json(value) == {"kind": "float", "value": "3.14"}
 
     @staticmethod
     def test_float_from_json() -> None:
-        serialized: Json = "3.14"
+        serialized: Json = {"kind": "float", "value": "3.14"}
         assert float_from_json(serialized) == Decimal("3.14")
 
 
@@ -74,11 +74,11 @@ class TestListSerializer:
         value = [1, 2, 3]
         serializer = list_to_json(int_to_json)
         serialized = serializer(value)
-        assert serialized == [1, 2, 3]
+        assert serialized == [int_to_json(1), int_to_json(2), int_to_json(3)]
 
     @staticmethod
     def test_list_from_json() -> None:
-        serialized: Json = [1, 2, 3]
+        serialized: Json = [int_to_json(1), int_to_json(2), int_to_json(3)]
         deserializer = list_from_json(int_from_json)
         value = deserializer(serialized)
         assert value == [1, 2, 3]

--- a/backend/libraries/ballerina-core-python/tests/parsing/sum_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/sum_test.py
@@ -22,13 +22,13 @@ class TestSumSerializer:
     @staticmethod
     def test_sum_from_json_left() -> None:
         serialized: Json = {"case": "left", "value": int_to_json(42)}
-        deserializer = sum_from_json(int_from_json, string_from_json)
-        value = deserializer(serialized)
+        parser = sum_from_json(int_from_json, string_from_json)
+        value = parser(serialized)
         assert value == Sum[int, str].left(42)
 
     @staticmethod
     def test_sum_from_json_right() -> None:
         serialized: Json = {"case": "right", "value": string_to_json("42")}
-        deserializer = sum_from_json(int_from_json, string_from_json)
-        value = deserializer(serialized)
+        parser = sum_from_json(int_from_json, string_from_json)
+        value = parser(serialized)
         assert value == Sum[int, str].right("42")

--- a/backend/libraries/ballerina-core-python/tests/parsing/sum_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/sum_test.py
@@ -1,5 +1,5 @@
 from ballerina_core.parsing.parsing_types import Json
-from ballerina_core.parsing.primitives import int_from_json, int_to_json, str_from_json, str_to_json
+from ballerina_core.parsing.primitives import int_from_json, int_to_json, string_from_json, string_to_json
 from ballerina_core.parsing.sum import sum_from_json, sum_to_json
 from ballerina_core.sum import Sum
 
@@ -8,27 +8,27 @@ class TestSumSerializer:
     @staticmethod
     def test_sum_to_json_left() -> None:
         value = Sum[int, str].left(42)
-        serializer = sum_to_json(int_to_json, str_to_json)
+        serializer = sum_to_json(int_to_json, string_to_json)
         serialized = serializer(value)
         assert serialized == {"case": "left", "value": 42}
 
     @staticmethod
     def test_sum_to_json_right() -> None:
         value = Sum[int, str].right("42")
-        serializer = sum_to_json(int_to_json, str_to_json)
+        serializer = sum_to_json(int_to_json, string_to_json)
         serialized = serializer(value)
         assert serialized == {"case": "right", "value": "42"}
 
     @staticmethod
     def test_sum_from_json_left() -> None:
         serialized: Json = {"case": "left", "value": 42}
-        deserializer = sum_from_json(int_from_json, str_from_json)
+        deserializer = sum_from_json(int_from_json, string_from_json)
         value = deserializer(serialized)
         assert value == Sum[int, str].left(42)
 
     @staticmethod
     def test_sum_from_json_right() -> None:
         serialized: Json = {"case": "right", "value": "42"}
-        deserializer = sum_from_json(int_from_json, str_from_json)
+        deserializer = sum_from_json(int_from_json, string_from_json)
         value = deserializer(serialized)
         assert value == Sum[int, str].right("42")

--- a/backend/libraries/ballerina-core-python/tests/parsing/sum_test.py
+++ b/backend/libraries/ballerina-core-python/tests/parsing/sum_test.py
@@ -10,25 +10,25 @@ class TestSumSerializer:
         value = Sum[int, str].left(42)
         serializer = sum_to_json(int_to_json, string_to_json)
         serialized = serializer(value)
-        assert serialized == {"case": "left", "value": 42}
+        assert serialized == {"case": "left", "value": int_to_json(42)}
 
     @staticmethod
     def test_sum_to_json_right() -> None:
         value = Sum[int, str].right("42")
         serializer = sum_to_json(int_to_json, string_to_json)
         serialized = serializer(value)
-        assert serialized == {"case": "right", "value": "42"}
+        assert serialized == {"case": "right", "value": string_to_json("42")}
 
     @staticmethod
     def test_sum_from_json_left() -> None:
-        serialized: Json = {"case": "left", "value": 42}
+        serialized: Json = {"case": "left", "value": int_to_json(42)}
         deserializer = sum_from_json(int_from_json, string_from_json)
         value = deserializer(serialized)
         assert value == Sum[int, str].left(42)
 
     @staticmethod
     def test_sum_from_json_right() -> None:
-        serialized: Json = {"case": "right", "value": "42"}
+        serialized: Json = {"case": "right", "value": string_to_json("42")}
         deserializer = sum_from_json(int_from_json, string_from_json)
         value = deserializer(serialized)
         assert value == Sum[int, str].right("42")


### PR DESCRIPTION
The big dilemma is unit, as Python and the other stupid languages allow functions with zero inputs which are not values.

I decided to go with the safer and stricter approach:
- option is `T + Unit`
- as such the parser takes as arguments the parser for T and the parser for unit
- The user interface is still convenient, as a went with `Option.none()` instead of `Option.none(unit)`



Also, I defined an explicit unit type as an empty tuple, sticking to the categorical definition of ADTs.

Errors are still crap, this needs to be changed to use explicit Sums so that tracing can yield a good user error