### PR TITLE
refactor: removed dependency on ParsedFormContext when paring types

### DIFF
--- a/backend/apps/ballerina-core.Tests/business rule engine/parser/common.fs
+++ b/backend/apps/ballerina-core.Tests/business rule engine/parser/common.fs
@@ -10,5 +10,5 @@ let assertSuccess<'T, 'E> (result: Sum<'T, 'E>) (expected: 'T) =
   | Left value -> Assert.That(value, Is.EqualTo expected)
   | Right err -> Assert.Fail($"Expected success but got error: {err}")
 
-let contextActions: ContextActions<unit> =
+let contextActions: ContextOperations<unit> =
   { TryFindType = fun _ _ -> sum.Throw(Errors.Singleton "Type lookup not expected") }

--- a/backend/libraries/ballerina-core/business rule engine/exprtype/model.fs
+++ b/backend/libraries/ballerina-core/business rule engine/exprtype/model.fs
@@ -4,8 +4,6 @@ namespace Ballerina.DSL.Expr.Types
 
 module Model =
   open System
-  open Ballerina.Fun
-  open Ballerina.Collections.Option
   open Ballerina.Collections.Map
   open Ballerina.Collections.Sum
   open Ballerina.Errors
@@ -17,6 +15,8 @@ module Model =
     { TypeId: TypeId
       Type: ExprType
       Const: bool }
+
+  and TypeContext = Map<string, TypeBinding>
 
   and TypeBindings = Map<TypeId, ExprType>
   and TypeId = { TypeName: string }

--- a/backend/libraries/ballerina-core/business rule engine/form engine/model.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/model.fs
@@ -466,8 +466,6 @@ module Model =
       StreamIdFieldName: string
       StreamDisplayValueFieldName: string }
 
-  type TypeContext = Map<string, TypeBinding>
-
   type ParsedFormsContext =
     { Types: TypeContext
       Apis: FormApis

--- a/backend/libraries/ballerina-core/business rule engine/form engine/model.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/model.fs
@@ -4,7 +4,6 @@ module Model =
   open Ballerina.DSL.Expr.Model
   open Ballerina.DSL.Expr.Types.Model
   open System
-  open FSharp.Data
 
   type CodeGenConfig =
     { Int: CodegenConfigTypeDef

--- a/backend/libraries/ballerina-core/business rule engine/form engine/model.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/model.fs
@@ -466,8 +466,10 @@ module Model =
       StreamIdFieldName: string
       StreamDisplayValueFieldName: string }
 
+  type TypeContext = Map<string, TypeBinding>
+
   type ParsedFormsContext =
-    { Types: Map<string, TypeBinding>
+    { Types: TypeContext
       Apis: FormApis
       Forms: Map<string, FormConfig>
       GenericRenderers:

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/formsPatterns.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/formsPatterns.fs
@@ -50,20 +50,6 @@ module FormsPatterns =
     member ctx.TryFindLauncher name =
       ctx.Launchers |> Map.tryFindWithError name "launcher" name
 
-  type ExprType with
-    static member Find (ctx: TypeContext) (typeId: TypeId) : Sum<ExprType, Errors> =
-      sum { return! TypeContext.TryFindType ctx typeId.TypeName |> Sum.map (fun tb -> tb.Type) }
-
-    static member ResolveLookup (ctx: TypeContext) (t: ExprType) : Sum<ExprType, Errors> =
-      sum {
-        match t with
-        | ExprType.LookupType l -> return! ExprType.Find ctx l
-        | ExprType.TableType t ->
-          let! t = ExprType.ResolveLookup ctx t
-          return ExprType.TableType t
-        | _ -> return t
-      }
-
   type StateBuilder with
     member state.TryFindType name =
       state {

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/formsPatterns.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/formsPatterns.fs
@@ -8,13 +8,6 @@ module FormsPatterns =
   open Ballerina.State.WithError
   open Ballerina.Errors
 
-  module TypeContext =
-    let ContextActions: ContextActions<TypeContext> =
-      { TryFindType = fun ctx name -> ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name }
-
-    let TryFindType ctx name =
-      ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name
-
   type ParsedFormsContext with
     static member ContextActions: ContextActions<ParsedFormsContext> =
       { TryFindType = fun ctx -> TypeContext.ContextActions.TryFindType ctx.Types }

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/formsPatterns.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/formsPatterns.fs
@@ -9,7 +9,7 @@ module FormsPatterns =
   open Ballerina.Errors
 
   module TypeContext =
-    let ContextActions: ContextActions<Map<string, TypeBinding>> =
+    let ContextActions: ContextActions<TypeContext> =
       { TryFindType = fun ctx name -> ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name }
 
     let TryFindType ctx name =
@@ -58,10 +58,10 @@ module FormsPatterns =
       ctx.Launchers |> Map.tryFindWithError name "launcher" name
 
   type ExprType with
-    static member Find (ctx: Map<string, TypeBinding>) (typeId: TypeId) : Sum<ExprType, Errors> =
+    static member Find (ctx: TypeContext) (typeId: TypeId) : Sum<ExprType, Errors> =
       sum { return! TypeContext.TryFindType ctx typeId.TypeName |> Sum.map (fun tb -> tb.Type) }
 
-    static member ResolveLookup (ctx: Map<string, TypeBinding>) (t: ExprType) : Sum<ExprType, Errors> =
+    static member ResolveLookup (ctx: TypeContext) (t: ExprType) : Sum<ExprType, Errors> =
       sum {
         match t with
         | ExprType.LookupType l -> return! ExprType.Find ctx l

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/formsPatterns.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/formsPatterns.fs
@@ -9,8 +9,8 @@ module FormsPatterns =
   open Ballerina.Errors
 
   type ParsedFormsContext with
-    static member ContextActions: ContextActions<ParsedFormsContext> =
-      { TryFindType = fun ctx -> TypeContext.ContextActions.TryFindType ctx.Types }
+    static member ContextOperations: ContextOperations<ParsedFormsContext> =
+      { TryFindType = fun ctx -> TypeContext.ContextOperations.TryFindType ctx.Types }
 
     member ctx.TryFindEnum name =
       ctx.Apis.Enums |> Map.tryFindWithError name "enum" name

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
@@ -365,7 +365,9 @@ module Runner =
       }
       |> state.MapError(Errors.Map(String.appendNewline $$"""...when parsing APIs"""))
 
-    static member ParseTypes(typesJson: seq<string * JsonValue>) : State<Unit, Unit, TypeContext, Errors> =
+    static member ParseTypes<'context>
+      (typesJson: seq<string * JsonValue>)
+      : State<Unit, 'context, TypeContext, Errors> =
       state {
 
         let! typesJson =
@@ -622,7 +624,7 @@ module Runner =
           State.mapState
             (fun context -> context.Types)
             (fun types -> ParsedFormsContext.Updaters.Types(fun _ -> types))
-            (State.mapContext (fun _ -> ()) (ParsedFormsContext.ParseTypes topLevel.Types))
+            (ParsedFormsContext.ParseTypes topLevel.Types)
 
         let! c = state.GetContext()
 

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
@@ -128,7 +128,7 @@ module Runner =
       : State<Unit, CodeGenConfig, ParsedFormsContext, Errors> =
 
       state {
-        let! enumType = ExprType.Parse ParsedFormsContext.ContextActions enumTypeJson
+        let! enumType = ExprType.Parse ParsedFormsContext.ContextOperations enumTypeJson
         let! enumTypeId = enumType |> ExprType.AsLookupId |> state.OfSum
         let! ctx = state.GetState()
         let! enumType = ExprType.ResolveLookup ctx.Types enumType |> state.OfSum
@@ -162,7 +162,7 @@ module Runner =
       (streamTypeJson: JsonValue)
       : State<StreamApi, CodeGenConfig, ParsedFormsContext, Errors> =
       state {
-        let! streamType = ExprType.Parse ParsedFormsContext.ContextActions streamTypeJson
+        let! streamType = ExprType.Parse ParsedFormsContext.ContextOperations streamTypeJson
         let! streamTypeId = streamType |> ExprType.AsLookupId |> state.OfSum
 
         return
@@ -206,7 +206,7 @@ module Runner =
 
         let! typeJson = (tableTypeFieldJsons |> state.TryFindField "type")
 
-        let! tableType = ExprType.Parse ParsedFormsContext.ContextActions typeJson
+        let! tableType = ExprType.Parse ParsedFormsContext.ContextOperations typeJson
         let! tableTypeId = tableType |> ExprType.AsLookupId |> state.OfSum
 
         let tableApi =
@@ -230,7 +230,7 @@ module Runner =
             (tableTypeFieldJsons |> state.TryFindField "methods")
 
         let! methodsJson = methodsJson |> JsonValue.AsArray |> state.OfSum
-        let! tableType = ExprType.Parse ParsedFormsContext.ContextActions typeJson
+        let! tableType = ExprType.Parse ParsedFormsContext.ContextOperations typeJson
         let! tableTypeId = tableType |> ExprType.AsLookupId |> state.OfSum
         let! methods = methodsJson |> Seq.map CrudMethod.Parse |> state.All |> state.Map Set.ofSeq
 
@@ -257,7 +257,7 @@ module Runner =
             (entityTypeFieldJsons |> state.TryFindField "methods")
 
         let! methodsJson = methodsJson |> JsonValue.AsArray |> state.OfSum
-        let! entityType = ExprType.Parse ParsedFormsContext.ContextActions typeJson
+        let! entityType = ExprType.Parse ParsedFormsContext.ContextOperations typeJson
         let! entityTypeId = entityType |> ExprType.AsLookupId |> state.OfSum
         let! methods = methodsJson |> Seq.map CrudMethod.Parse |> state.All |> state.Map Set.ofSeq
 
@@ -510,7 +510,7 @@ module Runner =
             |> Sum.fromOption (fun () -> Errors.Singleton $"Error: cannot parse generic type {tstring}")
             |> state.OfSum
 
-          let! t = ExprType.Parse ParsedFormsContext.ContextActions tjson
+          let! t = ExprType.Parse ParsedFormsContext.ContextOperations tjson
 
           do!
             state.SetState(

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
@@ -16,7 +16,6 @@ module Runner =
   open Ballerina.Errors
   open Ballerina.Core.Json
   open Ballerina.Core.String
-  open Ballerina.Core.Object
   open FSharp.Data
   open Ballerina.Collections.NonEmptyList
 
@@ -368,133 +367,7 @@ module Runner =
     static member ParseTypes<'context>
       (typesJson: seq<string * JsonValue>)
       : State<Unit, 'context, TypeContext, Errors> =
-      state {
-
-        let! typesJson =
-          typesJson
-          |> Seq.map (fun (name, json) ->
-            state {
-              let typeId: TypeId = { TypeName = name }
-
-              do!
-                state.SetState(
-                  Map.add
-                    name
-                    { Type = ExprType.UnitType
-                      TypeId = typeId
-                      Const = false }
-                )
-
-              return name, typeId, json
-            })
-          |> state.All
-
-        for typeName, typeId, typeJson in typesJson do
-          return!
-            state {
-              let! typeJsonArgs = typeJson |> JsonValue.AsRecord |> state.OfSum
-
-              return!
-                state.Any(
-                  NonEmptyList.OfList(
-                    state {
-                      let extendsJson =
-                        typeJsonArgs
-                        |> sum.TryFindField "extends"
-                        |> Sum.toOption
-                        |> Option.defaultWith (fun () -> JsonValue.Array [||])
-
-                      let isConstJson =
-                        typeJsonArgs
-                        |> sum.TryFindField "const"
-                        |> Sum.toOption
-                        |> Option.defaultWith (fun () -> JsonValue.Boolean false)
-
-                      let! fieldsJson = typeJsonArgs |> sum.TryFindField "fields" |> state.OfSum
-
-                      return!
-                        state {
-                          let! extends, fields, isConst =
-                            state.All3
-                              (extendsJson |> JsonValue.AsArray |> state.OfSum)
-                              (fieldsJson |> JsonValue.AsRecord |> state.OfSum)
-                              (isConstJson |> JsonValue.AsBoolean |> state.OfSum)
-
-                          let! s = state.GetState()
-
-                          let! extendedTypes =
-                            extends
-                            |> Seq.map (fun extendsJson ->
-                              state {
-                                let! parsed = ExprType.Parse TypeContext.ContextActions extendsJson
-                                return! ExprType.ResolveLookup s parsed |> state.OfSum
-                              })
-                            |> state.All
-
-                          let! fields =
-                            fields
-                            |> Seq.map (fun (fieldName, fieldType) ->
-                              state {
-                                let! fieldType = ExprType.Parse TypeContext.ContextActions fieldType
-                                return fieldName, fieldType
-                              }
-                              |> state.MapError(
-                                Errors.Map(String.appendNewline $"\n...when parsing field {fieldName}")
-                              ))
-                            |> Seq.toList
-                            |> state.All
-
-                          let fields = fields |> Map.ofList
-
-                          let! exprType =
-                            extendedTypes
-                            |> Seq.fold
-                              (fun (t1: Sum<ExprType, Errors>) t2 ->
-                                sum {
-                                  let! t1 = t1
-                                  return! ExprType.Extend t1 t2
-                                })
-                              (Left(ExprType.RecordType fields))
-                            |> state.OfSum
-
-                          do!
-                            state.SetState(
-                              Map.add
-                                typeName
-                                { Type = exprType
-                                  TypeId = typeId
-                                  Const = isConst }
-                            )
-
-                          return ()
-                        }
-                        |> state.MapError(Errors.WithPriority ErrorPriority.High)
-                    },
-                    [ state {
-                        let typeId: TypeId = { TypeName = typeName }
-
-                        let! parsedType = ExprType.Parse TypeContext.ContextActions typeJson
-
-                        do!
-                          state.SetState(
-                            Map.add
-                              typeName
-                              { Type = parsedType
-                                TypeId = typeId
-                                Const = false }
-                          )
-                      }
-                      state.Throw(
-                        Errors.Singleton
-                          $"...unexpected json shape for a type body {typeJson.ToFSharpString.ReasonablyClamped}"
-                        |> Errors.WithPriority ErrorPriority.High
-                      ) ]
-                  )
-                )
-            }
-            |> state.MapError(Errors.Map(String.appendNewline $"\n...when parsing type {typeName}"))
-      }
-      |> state.MapError(Errors.Map(String.appendNewline $"\n...when parsing types"))
+      ExprType.ParseTypes<'context> typesJson
 
     static member ParseForms
       (formsJson: (string * JsonValue)[])

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
@@ -365,7 +365,7 @@ module Runner =
       }
       |> state.MapError(Errors.Map(String.appendNewline $$"""...when parsing APIs"""))
 
-    static member ParseTypes(typesJson: seq<string * JsonValue>) : State<Unit, CodeGenConfig, TypeContext, Errors> =
+    static member ParseTypes(typesJson: seq<string * JsonValue>) : State<Unit, Unit, TypeContext, Errors> =
       state {
 
         let! typesJson =
@@ -622,7 +622,7 @@ module Runner =
           State.mapState
             (fun context -> context.Types)
             (fun types -> ParsedFormsContext.Updaters.Types(fun _ -> types))
-            (ParsedFormsContext.ParseTypes topLevel.Types)
+            (State.mapContext (fun _ -> ()) (ParsedFormsContext.ParseTypes topLevel.Types))
 
         let! c = state.GetContext()
 

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
@@ -365,9 +365,7 @@ module Runner =
       }
       |> state.MapError(Errors.Map(String.appendNewline $$"""...when parsing APIs"""))
 
-    static member ParseTypes
-      (typesJson: seq<string * JsonValue>)
-      : State<Unit, CodeGenConfig, Map<string, TypeBinding>, Errors> =
+    static member ParseTypes(typesJson: seq<string * JsonValue>) : State<Unit, CodeGenConfig, TypeContext, Errors> =
       state {
 
         let! typesJson =

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
@@ -16,6 +16,7 @@ module Runner =
   open Ballerina.Errors
   open Ballerina.Core.Json
   open Ballerina.Core.String
+  open Ballerina.Core.Object
   open FSharp.Data
   open Ballerina.Collections.NonEmptyList
 

--- a/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/parser/runner.fs
@@ -496,8 +496,8 @@ module Runner =
 
         do!
           State.mapState
-            (fun context -> context.Types)
-            (fun types -> ParsedFormsContext.Updaters.Types(fun _ -> types))
+            (fun outerState -> outerState.Types)
+            (fun innerState -> ParsedFormsContext.Updaters.Types(fun _ -> innerState))
             (ParsedFormsContext.ParseTypes topLevel.Types)
 
         let! c = state.GetContext()

--- a/backend/libraries/ballerina-core/business rule engine/form engine/validator.fs
+++ b/backend/libraries/ballerina-core/business rule engine/form engine/validator.fs
@@ -328,7 +328,7 @@ module Validator =
         | RecordType fields ->
           match fields |> Map.tryFind fc.FieldName with
           | Some fieldType ->
-            let! fieldType = ExprType.ResolveLookup ctx fieldType
+            let! fieldType = ExprType.ResolveLookup ctx.Types fieldType
 
             do!
               ExprType.Unify
@@ -893,8 +893,8 @@ module Validator =
   type EnumApi with
     static member Validate valueFieldName (ctx: ParsedFormsContext) (enumApi: EnumApi) : Sum<Unit, Errors> =
       sum {
-        let! enumType = ExprType.Find ctx enumApi.TypeId
-        let! enumType = ExprType.ResolveLookup ctx enumType
+        let! enumType = ExprType.Find ctx.Types enumApi.TypeId
+        let! enumType = ExprType.ResolveLookup ctx.Types enumType
         let! fields = ExprType.GetFields enumType
 
         let error =
@@ -905,7 +905,7 @@ module Validator =
 
         match fields with
         | [ (value, valuesType) ] when value = valueFieldName ->
-          let! valuesType = ExprType.ResolveLookup ctx valuesType
+          let! valuesType = ExprType.ResolveLookup ctx.Types valuesType
           let! cases = ExprType.GetCases valuesType
 
           if cases |> Map.values |> Seq.exists (fun case -> case.Fields.IsUnitType |> not) then
@@ -923,8 +923,8 @@ module Validator =
       (streamApi: StreamApi)
       : Sum<Unit, Errors> =
       sum {
-        let! streamType = ExprType.Find ctx streamApi.TypeId
-        let! streamType = ExprType.ResolveLookup ctx streamType
+        let! streamType = ExprType.Find ctx.Types streamApi.TypeId
+        let! streamType = ExprType.ResolveLookup ctx.Types streamType
         let! fields = ExprType.GetFields streamType
 
         let error =
@@ -950,8 +950,8 @@ module Validator =
       (tableApi: TableApi)
       : Sum<Unit, Errors> =
       sum {
-        let! tableType = ExprType.Find ctx tableApi.TypeId
-        let! tableType = ExprType.ResolveLookup ctx tableType
+        let! tableType = ExprType.Find ctx.Types tableApi.TypeId
+        let! tableType = ExprType.ResolveLookup ctx.Types tableType
         let! fields = ExprType.GetFields tableType
 
         let error =

--- a/backend/libraries/ballerina-core/business rule engine/parser/exprtype.fs
+++ b/backend/libraries/ballerina-core/business rule engine/parser/exprtype.fs
@@ -12,7 +12,8 @@ module ExprType =
   open Ballerina.Core.String
   open FSharp.Data
   open Ballerina.Collections.NonEmptyList
-
+  open Ballerina.Collections.Sum
+  open Ballerina.Core.Object
 
   type ExprType with
     static member ParseUnionCase<'config, 'context>
@@ -370,3 +371,134 @@ module ExprType =
           )
       }
       |> state.MapError(Errors.HighestPriority)
+
+    static member ParseTypes<'context>
+      (typesJson: seq<string * JsonValue>)
+      : State<Unit, 'context, TypeContext, Errors> =
+      state {
+
+        let! typesJson =
+          typesJson
+          |> Seq.map (fun (name, json) ->
+            state {
+              let typeId: TypeId = { TypeName = name }
+
+              do!
+                state.SetState(
+                  Map.add
+                    name
+                    { Type = ExprType.UnitType
+                      TypeId = typeId
+                      Const = false }
+                )
+
+              return name, typeId, json
+            })
+          |> state.All
+
+        for typeName, typeId, typeJson in typesJson do
+          return!
+            state {
+              let! typeJsonArgs = typeJson |> JsonValue.AsRecord |> state.OfSum
+
+              return!
+                state.Any(
+                  NonEmptyList.OfList(
+                    state {
+                      let extendsJson =
+                        typeJsonArgs
+                        |> sum.TryFindField "extends"
+                        |> Sum.toOption
+                        |> Option.defaultWith (fun () -> JsonValue.Array [||])
+
+                      let isConstJson =
+                        typeJsonArgs
+                        |> sum.TryFindField "const"
+                        |> Sum.toOption
+                        |> Option.defaultWith (fun () -> JsonValue.Boolean false)
+
+                      let! fieldsJson = typeJsonArgs |> sum.TryFindField "fields" |> state.OfSum
+
+                      return!
+                        state {
+                          let! extends, fields, isConst =
+                            state.All3
+                              (extendsJson |> JsonValue.AsArray |> state.OfSum)
+                              (fieldsJson |> JsonValue.AsRecord |> state.OfSum)
+                              (isConstJson |> JsonValue.AsBoolean |> state.OfSum)
+
+                          let! s = state.GetState()
+
+                          let! extendedTypes =
+                            extends
+                            |> Seq.map (fun extendsJson ->
+                              state {
+                                let! parsed = ExprType.Parse TypeContext.ContextActions extendsJson
+                                return! ExprType.ResolveLookup s parsed |> state.OfSum
+                              })
+                            |> state.All
+
+                          let! fields =
+                            fields
+                            |> Seq.map (fun (fieldName, fieldType) ->
+                              state {
+                                let! fieldType = ExprType.Parse TypeContext.ContextActions fieldType
+                                return fieldName, fieldType
+                              }
+                              |> state.MapError(
+                                Errors.Map(String.appendNewline $"\n...when parsing field {fieldName}")
+                              ))
+                            |> Seq.toList
+                            |> state.All
+
+                          let fields = fields |> Map.ofList
+
+                          let! exprType =
+                            extendedTypes
+                            |> Seq.fold
+                              (fun (t1: Sum<ExprType, Errors>) t2 ->
+                                sum {
+                                  let! t1 = t1
+                                  return! ExprType.Extend t1 t2
+                                })
+                              (Left(ExprType.RecordType fields))
+                            |> state.OfSum
+
+                          do!
+                            state.SetState(
+                              Map.add
+                                typeName
+                                { Type = exprType
+                                  TypeId = typeId
+                                  Const = isConst }
+                            )
+
+                          return ()
+                        }
+                        |> state.MapError(Errors.WithPriority ErrorPriority.High)
+                    },
+                    [ state {
+                        let typeId: TypeId = { TypeName = typeName }
+
+                        let! parsedType = ExprType.Parse TypeContext.ContextActions typeJson
+
+                        do!
+                          state.SetState(
+                            Map.add
+                              typeName
+                              { Type = parsedType
+                                TypeId = typeId
+                                Const = false }
+                          )
+                      }
+                      state.Throw(
+                        Errors.Singleton
+                          $"...unexpected json shape for a type body {typeJson.ToFSharpString.ReasonablyClamped}"
+                        |> Errors.WithPriority ErrorPriority.High
+                      ) ]
+                  )
+                )
+            }
+            |> state.MapError(Errors.Map(String.appendNewline $"\n...when parsing type {typeName}"))
+      }
+      |> state.MapError(Errors.Map(String.appendNewline $"\n...when parsing types"))

--- a/backend/libraries/ballerina-core/business rule engine/parser/exprtype.fs
+++ b/backend/libraries/ballerina-core/business rule engine/parser/exprtype.fs
@@ -17,7 +17,7 @@ module ExprType =
 
   type ExprType with
     static member ParseUnionCase<'config, 'context>
-      (contextActions: ContextActions<'context>)
+      (contextActions: ContextOperations<'context>)
       (json: JsonValue)
       : State<UnionCase, 'config, 'context, Errors> =
       let (!) = ExprType.Parse contextActions
@@ -61,7 +61,7 @@ module ExprType =
       }
 
     static member Parse<'config, 'context>
-      (contextActions: ContextActions<'context>)
+      (contextActions: ContextOperations<'context>)
       (json: JsonValue)
       : State<ExprType, 'config, 'context, Errors> =
       let (!) = ExprType.Parse contextActions
@@ -433,7 +433,7 @@ module ExprType =
                             extends
                             |> Seq.map (fun extendsJson ->
                               state {
-                                let! parsed = ExprType.Parse TypeContext.ContextActions extendsJson
+                                let! parsed = ExprType.Parse TypeContext.ContextOperations extendsJson
                                 return! ExprType.ResolveLookup s parsed |> state.OfSum
                               })
                             |> state.All
@@ -442,7 +442,7 @@ module ExprType =
                             fields
                             |> Seq.map (fun (fieldName, fieldType) ->
                               state {
-                                let! fieldType = ExprType.Parse TypeContext.ContextActions fieldType
+                                let! fieldType = ExprType.Parse TypeContext.ContextOperations fieldType
                                 return fieldName, fieldType
                               }
                               |> state.MapError(
@@ -480,7 +480,7 @@ module ExprType =
                     [ state {
                         let typeId: TypeId = { TypeName = typeName }
 
-                        let! parsedType = ExprType.Parse TypeContext.ContextActions typeJson
+                        let! parsedType = ExprType.Parse TypeContext.ContextOperations typeJson
 
                         do!
                           state.SetState(

--- a/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
+++ b/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
@@ -7,11 +7,11 @@ module Patterns =
   open Ballerina.Errors
   open Ballerina.DSL.Expr.Types.Model
 
-  type ContextActions<'context> =
+  type ContextOperations<'context> =
     { TryFindType: 'context -> string -> Sum<TypeBinding, Errors> }
 
   module TypeContext =
-    let ContextActions: ContextActions<TypeContext> =
+    let ContextOperations: ContextOperations<TypeContext> =
       { TryFindType = fun ctx name -> ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name }
 
     let TryFindType (ctx: TypeContext) (name: string) : Sum<TypeBinding, Errors> =

--- a/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
+++ b/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
@@ -14,9 +14,8 @@ module Patterns =
     let ContextActions: ContextActions<TypeContext> =
       { TryFindType = fun ctx name -> ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name }
 
-    let TryFindType ctx name =
+    let TryFindType (ctx: TypeContext) (name: string) =
       ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name
-
 
   type SumBuilder with
     member sum.TryFindField name fields =

--- a/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
+++ b/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
@@ -27,3 +27,17 @@ module Patterns =
   type StateBuilder with
     member state.TryFindField name fields =
       fields |> sum.TryFindField name |> state.OfSum
+
+  type ExprType with
+    static member Find (ctx: TypeContext) (typeId: TypeId) : Sum<ExprType, Errors> =
+      sum { return! TypeContext.TryFindType ctx typeId.TypeName |> Sum.map (fun tb -> tb.Type) }
+
+    static member ResolveLookup (ctx: TypeContext) (t: ExprType) : Sum<ExprType, Errors> =
+      sum {
+        match t with
+        | ExprType.LookupType l -> return! ExprType.Find ctx l
+        | ExprType.TableType t ->
+          let! t = ExprType.ResolveLookup ctx t
+          return ExprType.TableType t
+        | _ -> return t
+      }

--- a/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
+++ b/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
@@ -10,6 +10,14 @@ module Patterns =
   type ContextActions<'context> =
     { TryFindType: 'context -> string -> Sum<TypeBinding, Errors> }
 
+  module TypeContext =
+    let ContextActions: ContextActions<TypeContext> =
+      { TryFindType = fun ctx name -> ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name }
+
+    let TryFindType ctx name =
+      ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name
+
+
   type SumBuilder with
     member sum.TryFindField name fields =
       fields

--- a/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
+++ b/backend/libraries/ballerina-core/business rule engine/parser/patterns.fs
@@ -14,7 +14,7 @@ module Patterns =
     let ContextActions: ContextActions<TypeContext> =
       { TryFindType = fun ctx name -> ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name }
 
-    let TryFindType (ctx: TypeContext) (name: string) =
+    let TryFindType (ctx: TypeContext) (name: string) : Sum<TypeBinding, Errors> =
       ctx |> Map.tryFindWithError<string, TypeBinding> name "type" name
 
   type SumBuilder with


### PR DESCRIPTION
- In the last commit I used the isomorphism between unit and the identity natural transformation to avoid `mapContext`
- I used a function on a module instead of a static member on a type as TypeContext is just an alias (and fine to keep it as such, so that all the Map functionality can be used directly), syntactically it looks the same