### PR TITLE
fix: fixed string representation and added tests

### DIFF
--- a/backend/apps/ballerina-core.Tests/ballerina-core.Tests.fsproj
+++ b/backend/apps/ballerina-core.Tests/ballerina-core.Tests.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="business rule engine/parser/common.fs" />
     <Compile Include="business rule engine/parser/exprtype.fs" />
     <Compile Include="business rule engine/parser/expr.fs" />
+    <Compile Include="business rule engine/expr/model.fs" />
     <Compile Include="Program.fs" />
   </ItemGroup>
 

--- a/backend/apps/ballerina-core.Tests/business rule engine/expr/model.fs
+++ b/backend/apps/ballerina-core.Tests/business rule engine/expr/model.fs
@@ -1,0 +1,73 @@
+module Ballerina.Core.Tests.BusinessRuleEngine.Expr.Model
+
+open NUnit.Framework
+open Ballerina.DSL.Expr.Model
+open System
+
+type TestCase = { expr: Expr; expected: string }
+
+let testCases =
+  [ { expr = Expr.Value Value.Unit
+      expected = "()" }
+    { expr = Expr.Value(Value.ConstInt 42)
+      expected = "42" }
+    { expr = Expr.Value(Value.ConstFloat 42m)
+      expected = "42" }
+    { expr = Expr.Value(Value.ConstString "42")
+      expected = "42" }
+    { expr = Expr.Value(Value.ConstBool true)
+      expected = "True" }
+    { expr = Expr.Value(Value.ConstGuid(Guid.Parse "00000000-0000-0000-0000-000000000000"))
+      expected = "00000000-0000-0000-0000-000000000000" }
+    { expr = Expr.Value(Value.CaseCons("Some", Value.ConstInt 42))
+      expected = "Some(42)" }
+    { expr = Expr.Value(Value.Tuple [ Value.ConstInt 42; Value.ConstString "42" ])
+      expected = "(42, 42)" }
+    { expr = Expr.Value(Value.Record(Map.ofList [ "x", Value.ConstInt 42; "y", Value.ConstString "42" ]))
+      expected = "{ x = 42; y = 42 }" }
+    { expr = Expr.Value(Value.Lambda({ VarName = "x" }, Expr.Value(Value.ConstInt 42)))
+      expected = "fun x -> 42" }
+    { expr = Expr.Value(Value.List [ Value.ConstInt 42; Value.ConstInt 43 ])
+      expected = "[42, 43]" }
+    { expr =
+        Expr.Apply(
+          Expr.Value(Value.Lambda({ VarName = "x" }, Expr.Value(Value.ConstInt 42))),
+          Expr.Value(Value.ConstInt 2)
+        )
+      expected = "(fun x -> 42)(2)" }
+    { expr = Expr.Binary(BinaryOperator.And, Expr.Value(Value.ConstBool true), Expr.Value(Value.ConstBool false))
+      expected = "(True And False)" }
+    { expr = Expr.Binary(BinaryOperator.Or, Expr.Value(Value.ConstBool true), Expr.Value(Value.ConstBool false))
+      expected = "(True Or False)" }
+    { expr = Expr.VarLookup { VarName = "x" }
+      expected = "x" }
+    { expr = Expr.MakeRecord(Map.ofList [ "x", Expr.Value(Value.ConstInt 42); "y", Expr.Value(Value.ConstString "42") ])
+      expected = "{ x = 42; y = 42 }" }
+    { expr =
+        Expr.RecordFieldLookup(
+          Expr.Value(Value.Record(Map.ofList [ "x", Value.ConstInt 42; "y", Value.ConstString "42" ])),
+          "x"
+        )
+      expected = "{ x = 42; y = 42 }.x" }
+    { expr = Expr.MakeTuple [ Expr.Value(Value.ConstInt 42); Expr.Value(Value.ConstString "42") ]
+      expected = "(42, 42)" }
+    { expr = Expr.MakeSet [ Expr.Value(Value.ConstInt 42); Expr.Value(Value.ConstString "42") ]
+      expected = "{42; 42}" }
+    { expr = Expr.Project(Expr.Value(Value.Tuple [ Value.ConstInt 42; Value.ConstString "42" ]), 0)
+      expected = "(42, 42).π0" }
+    { expr = Expr.MakeCase("Some", Expr.Value(Value.ConstInt 42))
+      expected = "Some(42)" }
+    { expr =
+        Expr.MatchCase(
+          Expr.Value(Value.CaseCons("Some", Value.ConstInt 42)),
+          Map.ofList
+            [ "Some", ({ VarName = "y" }, Expr.Value(Value.ConstInt 42))
+              "None", ({ VarName = "_" }, Expr.Value Value.Unit) ]
+        )
+      expected = "match Some(42) with | None(_) -> () | Some(y) -> 42" } ]
+
+[<TestCaseSource(nameof testCases)>]
+let ``Should correctly map to string for visualization`` (testCase: TestCase) =
+  let { expr = expr; expected = expected } = testCase
+  let stringRepresentation = expr.ToString()
+  Assert.That(stringRepresentation, Is.EqualTo expected)

--- a/backend/libraries/ballerina-core/business rule engine/expr/model.fs
+++ b/backend/libraries/ballerina-core/business rule engine/expr/model.fs
@@ -95,9 +95,13 @@ module Model =
           |> Seq.map (fun (fieldName, expr) -> $"{fieldName} = {expr.ToString()}")
 
         $"""{{ {String.Join("; ", formattedFields)} }}"""
-      | Value.Tuple vs -> $"""({String.Join(", ", vs |> Seq.map (fun v -> v.ToString()))})"""
+      | Value.Tuple vs ->
+        let formattedValues = vs |> Seq.map (fun v -> v.ToString())
+        $"""({String.Join(", ", formattedValues)})"""
       | Value.Var(_, v) -> v.ToString()
-      | Value.List vs -> $"""[{String.Join(", ", vs |> Seq.map (fun v -> v.ToString()))}]"""
+      | Value.List vs ->
+        let formattedValues = vs |> Seq.map (fun v -> v.ToString())
+        $"""[{String.Join(", ", formattedValues)}]"""
 
     member self.toObject =
       match self with

--- a/backend/libraries/ballerina-core/business rule engine/expr/model.fs
+++ b/backend/libraries/ballerina-core/business rule engine/expr/model.fs
@@ -88,11 +88,16 @@ module Model =
       | Value.ConstString v -> v.ToString()
       | Value.Lambda(v, b) -> $"fun {v.VarName} -> {b.ToString()}"
       | Value.Record fs ->
-        let eq = "=" in
-        $"{{ {fs |> Seq.map (fun f -> f.Key.ToString() + eq + f.Value.ToString())} |> String.Join ';' }}"
-      | Value.Tuple vs -> $"( {vs |> Seq.map (fun v -> v.ToString())} |> String.Join ',' )"
+        let formattedFields =
+          fs
+          |> Map.toSeq
+          |> Seq.sortBy (fun (fieldName, _) -> fieldName)
+          |> Seq.map (fun (fieldName, expr) -> $"{fieldName} = {expr.ToString()}")
+
+        $"""{{ {String.Join("; ", formattedFields)} }}"""
+      | Value.Tuple vs -> $"""({String.Join(", ", vs |> Seq.map (fun v -> v.ToString()))})"""
       | Value.Var(_, v) -> v.ToString()
-      | Value.List vs -> $"[ {vs |> Seq.map (fun v -> v.ToString())} |> String.Join ',' ]"
+      | Value.List vs -> $"""[{String.Join(", ", vs |> Seq.map (fun v -> v.ToString()))}]"""
 
     member self.toObject =
       match self with
@@ -113,10 +118,15 @@ module Model =
       | Value v -> v.ToString()
       | Apply(f, a) -> $"({f.ToString()})({a.ToString()})"
       | MakeRecord fs ->
-        let eq = "=" in
-        $"{{ {fs |> Seq.map (fun f -> f.Key.ToString() + eq + f.Value.ToString())} |> String.Join ';' }}"
-      | MakeTuple fs -> $"({fs |> Seq.map (fun f -> f.ToString())} |> String.Join ',')"
-      | MakeSet fs -> $"{{ {fs |> Seq.map (fun f -> f.ToString())} |> String.Join ';' }}"
+        let formattedFields =
+          fs
+          |> Map.toSeq
+          |> Seq.sortBy (fun (fieldName, _) -> fieldName)
+          |> Seq.map (fun (fieldName, expr) -> $"{fieldName} = {expr.ToString()}")
+
+        $"""{{ {String.Join("; ", formattedFields)} }}"""
+      | MakeTuple fs -> $"""({String.Join(", ", fs |> Seq.map (fun f -> f.ToString()))})"""
+      | MakeSet fs -> $"""{{{String.Join("; ", fs |> Seq.map (fun f -> f.ToString()))}}}"""
       | RecordFieldLookup(e, f) -> $"{e.ToString()}.{f}"
       | MakeCase(c, e) -> $"{c.ToString()}({e.ToString()})"
       | Project(e, f) -> $"{e.ToString()}.π{f}"
@@ -124,11 +134,11 @@ module Model =
       | Exists(v, t, e) -> $"Exists{v.VarName.ToString()} in {t.EntityName} | {e.ToString()}"
       | SumBy(v, t, e) -> $"SumBy{v.VarName.ToString()} in {t.EntityName} | {e.ToString()}"
       | MatchCase(e, cases) ->
-        let bar = "|"
-        let arr = "->"
-
         let cases =
-          cases |> Seq.map (fun f -> bar + f.Key.ToString() + arr + f.Value.ToString())
+          cases
+          |> Map.toSeq
+          |> Seq.sortBy (fun (caseName, _) -> caseName)
+          |> Seq.map (fun (caseName, (varName, expr)) -> $"| {caseName}({varName.VarName}) -> {expr.ToString()}")
 
         let casesJoined = String.Join(' ', cases)
         $"match {e.ToString()} with {casesJoined}"


### PR DESCRIPTION
Some were completely wrong, as the string formatting was off, and what was supposed to be code was a string

```
        Expected: "{42; 42}"
        But was:  "{ Microsoft.FSharp.Collections.IEnumerator+mkSeq@177[System.S..."
```