### PR TITLE
fix: discriminator casing for consistent API conversion

### DIFF
--- a/frontend/apps/web/src/domains/dispatched-passthrough-form/apis/field-converters.ts
+++ b/frontend/apps/web/src/domains/dispatched-passthrough-form/apis/field-converters.ts
@@ -167,15 +167,15 @@ export const DispatchFieldTypeConverters: DispatchApiConverters<DispatchPassthro
     SumN: {
       fromAPIRawValue: (_: any) => {
         const caseIndex =
-          parseInt(_.Discriminator.split("of")[0].split("case")[1]) - 1;
-        const arity = parseInt(_.Discriminator.split("of")[1]);
+          parseInt(_.Discriminator.split("Of")[0].split("case")[1]) - 1;
+        const arity = parseInt(_.Discriminator.split("Of")[1]);
         const discriminator = `Case${caseIndex + 1}`;
 
         return ValueSumN.Default(caseIndex, arity, _[discriminator]);
       },
       toAPIRawValue: ([_, __]) => {
         return {
-          Discriminator: `case${_.caseIndex + 1}of${_.arity}`,
+          Discriminator: `case${_.caseIndex + 1}Of${_.arity}`,
           [`Case${_.caseIndex + 1}`]: _.value,
         };
       },


### PR DESCRIPTION
Corrects the case-sensitive formatting of discriminator strings in the field converters to ensure consistent API communication.

* Updates the case sensitivity of the "Discriminator" from "of" to "Of" in parsing and serialization
* Maintains uniformity between API values and internal data representation

Ensure compatibility with existing API consumers; no additional testing required.